### PR TITLE
Recreate interface_config.js on container restart

### DIFF
--- a/web/rootfs/etc/cont-init.d/10-config
+++ b/web/rootfs/etc/cont-init.d/10-config
@@ -82,17 +82,19 @@ if [[ -f /config/custom-config.js ]]; then
     cat /config/custom-config.js >> /config/config.js
 fi
 
-if [[ ! -f /config/interface_config.js ]]; then
+if [[ ! -f /config/interface_config.js || -f /config/custom-interface_config.js ]]; then
     cp /defaults/interface_config.js /config/interface_config.js
-    if [[ -f /config/custom-interface_config.js ]]; then
-        cat /config/custom-interface_config.js >> /config/interface_config.js
-    fi
-
-    # It will remove parameter 'closedcaptions' from TOOLBAR_BUTTONS if ENABLE_TRANSCRIPTIONS is false,
-    # because it enabled by default, but not supported out of the box.
-    if [[ $ENABLE_TRANSCRIPTIONS -ne 1 && "$ENABLE_TRANSCRIPTIONS" != "true" ]]; then
-        sed -i \
-            -e "s#'closedcaptions', ##" \
-            /config/interface_config.js
-    fi
 fi
+
+if [[ -f /config/custom-interface_config.js ]]; then
+    cat /config/custom-interface_config.js >> /config/interface_config.js
+fi
+
+# It will remove parameter 'closedcaptions' from TOOLBAR_BUTTONS if ENABLE_TRANSCRIPTIONS is false,
+# because it enabled by default, but not supported out of the box.
+if [[ $ENABLE_TRANSCRIPTIONS -ne 1 && "$ENABLE_TRANSCRIPTIONS" != "true" ]]; then
+    sed -i \
+        -e "s#'closedcaptions', ##" \
+        /config/interface_config.js
+fi
+


### PR DESCRIPTION
Recreate interface_config.js on container restart if custom-interface_config.js exists.
The [docs](https://jitsi.github.io/handbook/docs/devops-guide/devops-guide-docker#jitsi-meet-web-configuration) mention that the config files are recreated on every container restart but interface_config.js is currently only recreated if it doesn't already exist.